### PR TITLE
Downgrade analyzer to be in step with flutter_test

### DIFF
--- a/dioc_generator/pubspec.yaml
+++ b/dioc_generator/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>2.0.0-dev <3.0.0'
 
 dependencies:
-  analyzer: ^0.32.5
+  analyzer: ^0.32.4
   build: ^0.12.7+3
   dart_style: ^1.1.3
   source_gen: ^0.9.0+1


### PR DESCRIPTION
flutter_test currently specifies analyzer version 0.32.4.  As this is a package that is included by default with new flutter apps generated by the tooling, it makes sense to keep dioc compatible.  

This should not break anything for current users as it is a downgrade.